### PR TITLE
Fix old NX_SERVER_ env variables

### DIFF
--- a/apps/helm-chart/src/Chart.yaml
+++ b/apps/helm-chart/src/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: graphoenix
 description: Graphoenix Helm Chart
 type: application
-version: "0.6.0"
+version: "0.6.1"
 appVersion: "v0.6.0"
 keywords:
   - graphoenix

--- a/apps/helm-chart/src/templates/_helpers.tpl
+++ b/apps/helm-chart/src/templates/_helpers.tpl
@@ -37,22 +37,22 @@ Create the embedded MinIO S3 settings.
 */}}
 {{- define "graphoenix.server.s3.settings" -}}
 {{- if .Values.minio.enabled -}}
-- name: NX_SERVER_STORAGE_TYPE
+- name: GRAPHOENIX_SERVER_STORAGE_TYPE
   value: "s3"
-- name: NX_SERVER_STORAGE_S3_ENDPOINT
+- name: GRAPHOENIX_SERVER_STORAGE_S3_ENDPOINT
   value: "http://{{ template "graphoenix.name" . }}-minio.{{ .Release.Namespace }}.svc.cluster.local:9000"
-- name: NX_SERVER_STORAGE_S3_REGION
+- name: GRAPHOENIX_SERVER_STORAGE_S3_REGION
   value: "us-east-1"
-- name: NX_SERVER_STORAGE_S3_BUCKET
+- name: GRAPHOENIX_SERVER_STORAGE_S3_BUCKET
   value: "graphoenix"
-- name: NX_SERVER_STORAGE_S3_FORCE_PATH_STYLE
+- name: GRAPHOENIX_SERVER_STORAGE_S3_FORCE_PATH_STYLE
   value: "true"
-- name: NX_SERVER_STORAGE_S3_ACCESS_KEY_ID
+- name: GRAPHOENIX_SERVER_STORAGE_S3_ACCESS_KEY_ID
   valueFrom:
     secretKeyRef:
       name: {{ template "graphoenix.name" . }}-minio
       key: root-user
-- name: NX_SERVER_STORAGE_S3_SECRET_ACCESS_KEY
+- name: GRAPHOENIX_SERVER_STORAGE_S3_SECRET_ACCESS_KEY
   valueFrom:
     secretKeyRef:
       name: {{ template "graphoenix.name" . }}-minio

--- a/apps/helm-chart/src/templates/server/cleanup.cron-job.yaml
+++ b/apps/helm-chart/src/templates/server/cleanup.cron-job.yaml
@@ -63,7 +63,7 @@ spec:
                 {{- with (concat .Values.global.env .Values.server.env) }}
                   {{- toYaml . | nindent 16 }}
                 {{- end }}
-                - name: NX_SERVER_CONFIGURATION_APPLICATION_URL
+                - name: GRAPHOENIX_SERVER_CONFIGURATION_APPLICATION_URL
                   value: {{ .Values.global.domain }}
                 - name: QUARKUS_MONGODB_CONNECTION_STRING
                   {{- include "graphoenix.server.database.connection-string" . | nindent 18 }}

--- a/apps/helm-chart/src/templates/server/deployment.yaml
+++ b/apps/helm-chart/src/templates/server/deployment.yaml
@@ -57,7 +57,7 @@ spec:
           {{- with (concat .Values.global.env .Values.server.env) }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
-          - name: NX_SERVER_CONFIGURATION_APPLICATION_URL
+          - name: GRAPHOENIX_SERVER_CONFIGURATION_APPLICATION_URL
             value: {{ .Values.global.domain }}
           - name: QUARKUS_MONGODB_CONNECTION_STRING
             {{- include "graphoenix.server.database.connection-string" . | nindent 12 }}


### PR DESCRIPTION
Renamed old NX_SERVER_ environment variables to GRAPHOENIX_SERVER_ to fix deployment and helpers.
Bumped chart version to v0.6.1